### PR TITLE
Improves mod list generation and removes unused code

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -134,11 +134,13 @@ fn command_line_convert(modpreset: &str, backticks: bool) -> Result<ModData, Str
         }
         if OPTIONAL_MODS.contains(&&*mod_name) {
             optional_mods.push(mod_name.clone());
+            continue;
         }
         mod_list.push(mod_name);
     }
 
     mod_list.sort_by_key(|a| a.to_lowercase());
+    optional_mods.sort_by_key(|a| a.to_lowercase());
 
     for required_mod in REQUIRED_MODS {
         if !mod_list.contains(&required_mod.to_string()) {
@@ -153,9 +155,25 @@ fn command_line_convert(modpreset: &str, backticks: bool) -> Result<ModData, Str
     }
 
     let mods = if backticks {
-        format!("```\n{}\n```", mod_list.join(";"))
+        format!(
+            "```\n{}{}\n```",
+            mod_list.join(";"),
+            if !optional_mods.is_empty() {
+                format!(";{}", optional_mods.join(";"))
+            } else {
+                String::new()
+            }
+        )
     } else {
-        mod_list.join(";")
+        format!(
+            "{}{}",
+            mod_list.join(";"),
+            if !optional_mods.is_empty() {
+                format!(";{}", optional_mods.join(";"))
+            } else {
+                String::new()
+            }
+        )
     };
 
     Ok(ModData {


### PR DESCRIPTION
Enhances the command line mod list generation functionality and cleans up the codebase:

### Improvements
- Moves optional mods to the end of the generated command line output
- Adds sorting for optional mods list for consistent ordering

### Cleanup
- Removes unused `VERSION` static variable and associated `Arc` synchronization
- Removes unnecessary imports that were no longer being used

### Technical Details
- Adds a `continue` statement after adding a mod to optional mods to prevent duplication
- Maintains consistent formatting whether using backticks or plain output
- Preserves semicolon-based separation between required and optional mods

This change improves the readability of generated mod lists while maintaining backward compatibility with existing functionality.